### PR TITLE
Split Processors into their own library, drop internal boost

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,20 +25,17 @@ INCLUDE( ilcsoft_default_settings )
 
 
 FIND_PACKAGE( Marlin 1.0 REQUIRED ) # minimum required Marlin version
-LINK_LIBRARIES( ${Marlin_LIBRARIES} )
 INCLUDE_DIRECTORIES( SYSTEM ${Marlin_INCLUDE_DIRS} )
 ADD_DEFINITIONS( ${Marlin_DEFINITIONS} )
 
 
 FIND_PACKAGE( MarlinUtil REQUIRED ) # minimum required Marlin version
-LINK_LIBRARIES( ${MarlinUtil_LIBRARIES} )
 INCLUDE_DIRECTORIES( SYSTEM ${MarlinUtil_INCLUDE_DIRS} )
 
 
 # optional package
 FIND_PACKAGE( AIDA )
 IF( AIDA_FOUND )
-    LINK_LIBRARIES( ${AIDA_LIBRARIES} )
     INCLUDE_DIRECTORIES( SYSTEM ${AIDA_INCLUDE_DIRS} )
     ADD_DEFINITIONS( "-DMARLIN_USE_AIDA" )
     MESSAGE( STATUS "AIDA: ${AIDA_DIR}" )
@@ -95,7 +92,7 @@ endif()
 AUX_SOURCE_DIRECTORY( ./src processor_srcs )
 AUX_SOURCE_DIRECTORY( ./diagnostics/src diagnostics_srcs )
 FILE( GLOB_RECURSE vertex_lcfi_srcs "vertex_lcfi/*.cpp" )
-SET( library_sources ${processor_srcs} ${diagnostics_srcs} ${vertex_lcfi_srcs} )
+SET( library_sources ${diagnostics_srcs} ${vertex_lcfi_srcs} )
 
 
 # add library
@@ -104,7 +101,14 @@ if(NOT BOOST_ROOT )
   ADD_DEPENDENCIES( ${PROJECT_NAME} unpack_boost ) # unpack boost (if needed)
 endif()
 
+ADD_SHARED_LIBRARY( ${PROJECT_NAME}Processors ${processor_srcs} )
+
+TARGET_LINK_LIBRARIES( ${PROJECT_NAME} ${Marlin_LIBRARIES} ${MarlinUtil_LIBRARIES} ${AIDA_LIBRARIES} )
+TARGET_LINK_LIBRARIES( ${PROJECT_NAME}Processors ${PROJECT_NAME} )
+
 INSTALL_SHARED_LIBRARY( ${PROJECT_NAME} DESTINATION lib )
+INSTALL_SHARED_LIBRARY( ${PROJECT_NAME}Processors DESTINATION lib )
+
 
 # display some variables and write them to cache
 DISPLAY_STD_VARIABLES()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,19 +62,9 @@ ENDIF()
 
 
 # -------------------- boost ------------------------------------------------------
-if( BOOST_ROOT )
-  find_package( Boost REQUIRED ) 
-  include_directories( SYSTEM ${Boost_INCLUDE_DIRS} )
-  SET( LCFI_USE_EXTERNAL_BOOST 1)
-else()  
-  # custom command to unpack boost (if needed)
-  ADD_CUSTOM_COMMAND(
-    OUTPUT "${PROJECT_SOURCE_DIR}/include/boost/config.hpp"
-    COMMAND tar xzvf boost.tgz
-    WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
-    )
-  ADD_CUSTOM_TARGET( unpack_boost DEPENDS "${PROJECT_SOURCE_DIR}/include/boost/config.hpp" )
-endif()
+find_package( Boost REQUIRED )
+include_directories( SYSTEM ${Boost_INCLUDE_DIRS} )
+SET( LCFI_USE_EXTERNAL_BOOST 1)
 # ---------------------------------------------------------------------------------
 
 
@@ -87,10 +77,6 @@ INCLUDE_DIRECTORIES( ./include ./vertex_lcfi ./vertex_lcfi/nnet/inc ./diagnostic
 
 INSTALL_DIRECTORY( ./vertex_lcfi DESTINATION include FILES_MATCHING PATTERN "*.h*" )
 
-if(NOT BOOST_ROOT )
-  INSTALL_DIRECTORY( ./include/boost DESTINATION include FILES_MATCHING PATTERN "*.h*" )
-endif()
-
 # get list of all source files
 AUX_SOURCE_DIRECTORY( ./src processor_srcs )
 AUX_SOURCE_DIRECTORY( ./diagnostics/src diagnostics_srcs )
@@ -100,9 +86,6 @@ FILE( GLOB_RECURSE vertex_lcfi_srcs "vertex_lcfi/*.cpp" )
 SET( library_sources ${vertex_lcfi_srcs} )
 # add library
 ADD_SHARED_LIBRARY( ${PROJECT_NAME} ${library_sources} )
-if(NOT BOOST_ROOT )
-  ADD_DEPENDENCIES( ${PROJECT_NAME} unpack_boost ) # unpack boost (if needed)
-endif()
 
 ADD_SHARED_LIBRARY( ${PROJECT_NAME}Processors ${processor_srcs} ${diagnostics_srcs} )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,9 @@ FIND_PACKAGE( Marlin 1.0 REQUIRED ) # minimum required Marlin version
 INCLUDE_DIRECTORIES( SYSTEM ${Marlin_INCLUDE_DIRS} )
 ADD_DEFINITIONS( ${Marlin_DEFINITIONS} )
 
+FIND_PACKAGE( LCIO REQUIRED )
+INCLUDE_DIRECTORIES( SYSTEM ${LCIO_INCLUDE_DIRS} )
+ADD_DEFINITIONS( ${LCIO_DEFINITIONS} )
 
 FIND_PACKAGE( MarlinUtil REQUIRED ) # minimum required Marlin version
 INCLUDE_DIRECTORIES( SYSTEM ${MarlinUtil_INCLUDE_DIRS} )
@@ -92,19 +95,19 @@ endif()
 AUX_SOURCE_DIRECTORY( ./src processor_srcs )
 AUX_SOURCE_DIRECTORY( ./diagnostics/src diagnostics_srcs )
 FILE( GLOB_RECURSE vertex_lcfi_srcs "vertex_lcfi/*.cpp" )
-SET( library_sources ${diagnostics_srcs} ${vertex_lcfi_srcs} )
 
 
+SET( library_sources ${vertex_lcfi_srcs} )
 # add library
 ADD_SHARED_LIBRARY( ${PROJECT_NAME} ${library_sources} )
 if(NOT BOOST_ROOT )
   ADD_DEPENDENCIES( ${PROJECT_NAME} unpack_boost ) # unpack boost (if needed)
 endif()
 
-ADD_SHARED_LIBRARY( ${PROJECT_NAME}Processors ${processor_srcs} )
+ADD_SHARED_LIBRARY( ${PROJECT_NAME}Processors ${processor_srcs} ${diagnostics_srcs} )
 
-TARGET_LINK_LIBRARIES( ${PROJECT_NAME} ${Marlin_LIBRARIES} ${MarlinUtil_LIBRARIES} ${AIDA_LIBRARIES} )
-TARGET_LINK_LIBRARIES( ${PROJECT_NAME}Processors ${PROJECT_NAME} )
+TARGET_LINK_LIBRARIES( ${PROJECT_NAME} ${MarlinUtil_LIBRARIES} ${LCIO_LIBRARIES} )
+TARGET_LINK_LIBRARIES( ${PROJECT_NAME}Processors ${Marlin_LIBRARIES} ${AIDA_LIBRARIES} ${PROJECT_NAME} )
 
 INSTALL_SHARED_LIBRARY( ${PROJECT_NAME} DESTINATION lib )
 INSTALL_SHARED_LIBRARY( ${PROJECT_NAME}Processors DESTINATION lib )

--- a/vertex_lcfi/src/TState.cpp
+++ b/vertex_lcfi/src/TState.cpp
@@ -4,12 +4,12 @@
 #include "../util/inc/matrix.h"
 #include "../util/inc/vector3.h"
 
-#include <marlin/Global.h>
-#include <gear/BField.h>
-
 // local
 
 #include "../inc/TState.h"
+
+#include <marlinutil/GeometryUtil.h>
+
 
 //-----------------------------------------------------------------------------
 // Implementation file for class : TState
@@ -35,7 +35,7 @@ TState::TState( TrackState* TrackState )
   
   fQ = ( TrackState->isNeutral() ? 0 : (int)TrackState->charge() );  
   fCLight = 0.000299792458;
-  fB = marlin::Global::GEAR->getBField().at(gear::Vector3D(0.,0.,0.)).z();
+  fB = MarlinUtil::getBzAtOrigin();
 
   double sinp = sin(helix.phi()); double cosp = cos(helix.phi());
   double d0 = helix.d0(); double z0 = helix.z0();


### PR DESCRIPTION
Fixes #2 , Fixes #3 

BEGINRELEASENOTES
- Split processors into their own library as some tools are used in LCFIPlus, ilcsoft/LCFIVertex#2
- Drop old boost tarball, rely in cvmfs/system installation of boost that is now needed elsewhere as well, ilcsoft/LCFIVertex#3
- TState: replace usage of gear with MarlinUtil to get bfield value

ENDRELEASENOTES